### PR TITLE
Upgrade pillow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ opencv-python-headless==4.1.2.30
 openpyxl==3.1.2
 paiargparse==1.1.2
 pandas==1.3.5
-pillow==8.2.0
+pillow==8.3.2
 prettytable==3.7.0
 python-Levenshtein==0.21.1
 scikit-image==0.17.2


### PR DESCRIPTION
To fix this error on docker build in Rodan: 

```
2023-07-06T15:43:03Z #12 37.34 scikit-image 0.17.2 depends on pillow!=7.1.0, !=7.1.1 and >=4.3.0
2023-07-06T15:43:03Z #12 37.34 tfaip 1.2.6 depends on pillow==8.2.0
2023-07-06T15:43:03Z #12 37.34 imageio 2.31.1 depends on pillow>=8.3.2
```